### PR TITLE
Check if method getLockFile exists

### DIFF
--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -320,8 +320,17 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
             $this->logger->log("\n".'<info>Running composer update to apply merge settings</info>');
 
             $file = Factory::getComposerFile();
-            $lock = Factory::getLockFile($file);
-            $lockBackup = file_exists($lock) ? file_get_contents($lock) : null;
+            $lock = null;
+            $lockBackup = null;
+
+
+            // on Composer version 1.8.0 method getLockFile does not exist
+            $rm = new \ReflectionMethod( new Factory, 'getLockFile');
+            $getLockFileMethosExists = $rm->isStatic();
+            if ($getLockFileMethosExists) {
+                $lock = Factory::getLockFile($file);
+                $lockBackup = file_exists($lock) ? file_get_contents($lock) : null;
+            }
 
             $config = $this->composer->getConfig();
             $preferSource = $config->get('preferred-install') == 'source';

--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -325,9 +325,7 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
 
 
             // on Composer version 1.8.0 method getLockFile does not exist
-            $rm = new \ReflectionMethod( new Factory, 'getLockFile');
-            $getLockFileMethosExists = $rm->isStatic();
-            if ($getLockFileMethosExists) {
+            if (method_exists(new Factory(), 'getLockFile')) {
                 $lock = Factory::getLockFile($file);
                 $lockBackup = file_exists($lock) ? file_get_contents($lock) : null;
             }


### PR DESCRIPTION
on Composer version 1.8.0 method getLockFile does not exist and leads to error

`PHP Fatal error:  Uncaught Error: Call to undefined method Composer\Factory::getLockFile() in G:\xampp\htdocs\project\vendor\wikimedia\composer-merge-plugin\src\MergePlugin.php:323`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mcaskill/composer-merge-plugin/1)
<!-- Reviewable:end -->
